### PR TITLE
Single navigation bar render

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -31,45 +31,47 @@ class App extends Component {
         return (
             <Fragment>
                 <LoadingBar />
-                { this.props.loading === true
-                    ? null
-                    : 
-                        <div>
-                            <NavigationBar />
-                            <Switch>
-                                <Route 
-                                    exact 
-                                    path='/login' 
-                                    name="Login Page" 
-                                    render={(props) => <LoginPage {...props} />}
-                                />
-                                <ProtectedRoute 
-                                    exact
-                                    path='/' 
-                                    name="Home Page"
-                                    component={HomePage} 
-                                />
-                                <ProtectedRoute 
-                                    exact 
-                                    path='/add' 
-                                    name="New Question"
-                                    component={NewQuestionPage} 
-                                />
-                                <ProtectedRoute 
-                                    path='/leaderboard' 
-                                    name="Leader Board"
-                                    component={LeaderBoardPage} 
-                                />
-                                <ProtectedRoute 
-                                    path='/questions/:id'
-                                    name="Question Details"
-                                    component={QuestionPage} 
-                                />
-                                <Route path="*" component={NotFound} />
-                                <Redirect to="/404" />
-                            </Switch>
-                        </div>         
-                        }
+                <div>
+                    <NavigationBar />
+                    { this.props.loading === true
+                        ? null
+                        :
+                            <div>
+                                <Switch>
+                                    <Route
+                                        exact
+                                        path='/login'
+                                        name="Login Page"
+                                        render={(props) => <LoginPage {...props} />}
+                                    />
+                                    <ProtectedRoute
+                                        exact
+                                        path='/'
+                                        name="Home Page"
+                                        component={HomePage}
+                                    />
+                                    <ProtectedRoute
+                                        exact
+                                        path='/add'
+                                        name="New Question"
+                                        component={NewQuestionPage}
+                                    />
+                                    <ProtectedRoute
+                                        path='/leaderboard'
+                                        name="Leader Board"
+                                        component={LeaderBoardPage}
+                                    />
+                                    <ProtectedRoute
+                                        path='/questions/:id'
+                                        name="Question Details"
+                                        component={QuestionPage}
+                                    />
+                                    <Route path="*" component={NotFound} />
+                                    <Redirect to="/404" />
+                                </Switch>
+                            </div>
+                    }
+                </div>
             </Fragment>
             )
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter as Redirect, Route, Switch } from 'react-router-dom'
 
 import { handleInitialData } from '../actions/shared'
 
+import NavigationBar from '../components/NavigationBar'
 import LoginPage from '../pages/LoginPage'
 import HomePage from '../pages/HomePage'
 import NewQuestionPage from '../pages/NewQuestionPage'
@@ -34,6 +35,7 @@ class App extends Component {
                     ? null
                     : 
                         <div>
+                            <NavigationBar />
                             <Switch>
                                 <Route 
                                     exact 

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -9,32 +9,41 @@ import { Navbar, Container, Nav, Button } from 'react-bootstrap'
  * This componenet render the navigation bar which sits at the top of each Page
  * component in the ../pages directory.
  */
+
+
 class NavigationBar extends Component{
 
-    state = {
-        logout: false,
-    }
+    // state = {
+        /*
+         * It turns out that keeping the logout state caused a problem of infinitly reloading the login
+         * page causing the state to be set to false infinitly which led to the program to crash.
+         * Removing logout fixed the issue and caused the app to operate correctly since the authedUser is
+         * already reset which automatically loads the login page (most likely because of the way the protected route
+         * is implemented)
+         */
+        //     logout: false,
+    // }
 
     logout = () => {
         const { dispatch } = this.props
 
         dispatch(setAuthedUser(""))
 
-        this.setState(() => ({
-            logout: true,
-        }))
+        // this.setState(() => ({
+        //     logout: true,
+        // }))
     }
 
     render(){
-        const { logout } = this.state
-        const { users, tabPath } = this.props
+        // const { logout } = this.state
+        // const { users, tabPath } = this.props
+        const { users } = this.props
+        const { tabPath } = this.props.location.pathname
 
 
-        console.log(logout);
-
-        if (logout) {
-            this.props.history.push('/login')
-        }
+        // if (logout) {
+        //     this.props.history.push('/login')
+        // }
 
         return(
             <div>
@@ -69,7 +78,7 @@ class NavigationBar extends Component{
                                     <Button 
                                         className="btn btn-outline-primary mr-1" 
                                         variant="warning"
-                                        onClick={this.logout    }
+                                        onClick={this.logout}
                                     >
                                         Logout
                                     </Button>
@@ -86,14 +95,20 @@ class NavigationBar extends Component{
 
 function mapStateToProps ({ authedUser, users }, props) {
 
-    const {tabPath} = props && Object.keys(props).length === 0 && props.constructor === Object
-    ? ""
-    : props.match.params
+    /*
+     * Since we placed a single navigation bar in the App component instead of one in each view.
+     * Now, we have to figure out a way to detect which path we are in since we do not have the 
+     * tabPath anymore.
+     */
+
+    // const {tabPath} = props && Object.keys(props).length === 0 && props.constructor === Object
+    // ? ""
+    // : props.match.params
 
     return {
         authedUser,
         users,
-        tabPath,
+        // tabPath,
     }
 }
 

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -15,7 +15,7 @@ class NavigationBar extends Component{
         logout: false,
     }
 
-    resetAuthedUser = () => {
+    logout = () => {
         const { dispatch } = this.props
 
         dispatch(setAuthedUser(""))
@@ -28,6 +28,9 @@ class NavigationBar extends Component{
     render(){
         const { logout } = this.state
         const { users, tabPath } = this.props
+
+
+        console.log(logout);
 
         if (logout) {
             this.props.history.push('/login')
@@ -66,7 +69,7 @@ class NavigationBar extends Component{
                                     <Button 
                                         className="btn btn-outline-primary mr-1" 
                                         variant="warning"
-                                        onClick={this.resetAuthedUser}
+                                        onClick={this.logout    }
                                     >
                                         Logout
                                     </Button>

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -15,13 +15,14 @@ import { Alert } from 'react-bootstrap'
 
 class Question extends Component {
 
-    state = {
-        toHome: false,
-    }
+    // state = {
+    //     toHome: false,
+    // }
 
     render() {        
         
-        const { question, authedUser, users, id, toHome} = this.props
+        // const { question, authedUser, users, id, toHome} = this.props
+        const { question, authedUser, users, id } = this.props
 
         /*
          * The required behavior was to stay on the same question page and show the results.

--- a/src/components/QuestionsList.js
+++ b/src/components/QuestionsList.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
-import { Alert } from 'react-bootstrap'
+import { Alert, Row, Card } from 'react-bootstrap'
 
 import QuestionCard from './QuestionCard';
 
@@ -38,16 +38,20 @@ class QuestionsList extends Component {
         else {
             return (
                 <div>
-                    <ul>
-                        {
-                        questionListIds.map((questionId) => (
-                            <li key={questionId} >
-                                <QuestionCard id={questionId}/>
-                            </li>
-                        ))
-                        }
-                    </ul>
-                </div>
+                                    <Row className="justify-content-md-center">
+                    <Card className="text-center" style={{ width: '50rem' }} >
+                        <ul>
+                            {
+                            questionListIds.map((questionId) => (
+                                <li key={questionId} >
+                                    <QuestionCard id={questionId}/>
+                                </li>
+                            ))
+                            }
+                        </ul>
+                                            </Card>
+                </Row>
+                    </div>
             )
         }
     }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 
 import { Tabs, Tab, Container, Card } from 'react-bootstrap'
 
-import NavigationBar from '../components/NavigationBar'
+// import NavigationBar from '../components/NavigationBar'
 import QuestionsList from '../components/QuestionsList'
 
 class HomePage extends Component {

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -10,7 +10,7 @@ class HomePage extends Component {
     render() {
         return(
             <div>
-                <NavigationBar match={{params: {tabPath: '/home'}}}/>
+                {/* <NavigationBar match={{params: {tabPath: '/home'}}}/> */}
                 <Container>
                     <Card bg='light' style={{ width: '55rem' }}>
                         <Card.Body>

--- a/src/pages/LeaderBoardPage.js
+++ b/src/pages/LeaderBoardPage.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import NavigationBar from '../components/NavigationBar'
+// import NavigationBar from '../components/NavigationBar'
 import LeaderBoard from '../components/LeaderBoard'
 
 class LeaderBoardPage extends Component{

--- a/src/pages/LeaderBoardPage.js
+++ b/src/pages/LeaderBoardPage.js
@@ -6,7 +6,7 @@ class LeaderBoardPage extends Component{
     render(){
         return(
             <div>
-                <NavigationBar match={{params: {tabPath: '/leaderboard'}}}/>
+                {/* <NavigationBar match={{params: {tabPath: '/leaderboard'}}}/> */}
                 <LeaderBoard />
             </div>
         )

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import Login from '../components/Login'
-import NavigationBar from '../components/NavigationBar'
+// import NavigationBar from '../components/NavigationBar'
 
 class LoginPage extends Component{
     render(){

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -6,7 +6,7 @@ class LoginPage extends Component{
     render(){
         return(
             <div>
-                <NavigationBar />
+                {/* <NavigationBar /> */}
                 <Login />
             </div>
         )

--- a/src/pages/NewQuestionPage.js
+++ b/src/pages/NewQuestionPage.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import NavigationBar from '../components/NavigationBar'
+// import NavigationBar from '../components/NavigationBar'
 import NewQuestion from '../components/NewQuestion'
 
 class NewQuestionPage extends Component{

--- a/src/pages/NewQuestionPage.js
+++ b/src/pages/NewQuestionPage.js
@@ -6,7 +6,7 @@ class NewQuestionPage extends Component{
     render(){
         return(
             <div>
-                <NavigationBar match={{params: {tabPath: '/new'}}}/>
+                {/* <NavigationBar match={{params: {tabPath: '/new'}}}/> */}
                 <NewQuestion />
             </div>
         )

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -4,7 +4,7 @@ import NavigationBar from "../components/NavigationBar";
 function NotFound() {
   return (
     <>
-      <NavigationBar />
+      {/* <NavigationBar /> */}
       <div>
         <span>404</span> page not found
       </div>

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,4 +1,4 @@
-import NavigationBar from "../components/NavigationBar";
+// import NavigationBar from "../components/NavigationBar";
 
 
 function NotFound() {

--- a/src/pages/QuestionPage.js
+++ b/src/pages/QuestionPage.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import NavigationBar from '../components/NavigationBar'
+// import NavigationBar from '../components/NavigationBar'
 
 import Question from '../components/Question'
 

--- a/src/pages/QuestionPage.js
+++ b/src/pages/QuestionPage.js
@@ -10,7 +10,7 @@ class QuestionPage extends Component{
 
         return(
             <div>
-                <NavigationBar />
+                {/* <NavigationBar /> */}
                 <Question match={{params: {id: id}}}/>
             </div>
         )


### PR DESCRIPTION
The navigation bar was repeatedly rendered in every view. This change removed that redundancy and added a single nav bar to the `App` component. This, however, caused a couple of issues:

1. The logout functionality was not working since it was recursively called leading the application to crash.

This problem was fixed by removing the local state of `logout` which was pushing the login page to the `history`. Removing the state fixed the issue

2. We can't use the props in which we pass the path for the navigation bar to correctly highlight the corresponding tab in the navigation bar.

This problem was solved by extracting the path from the `props.location` as described [here](https://stackoverflow.com/questions/42253277/react-router-v4-how-to-get-current-route)